### PR TITLE
Mejora en el listado de tareas públicas activas

### DIFF
--- a/src/main/java/acme/components/CustomCommand.java
+++ b/src/main/java/acme/components/CustomCommand.java
@@ -15,5 +15,5 @@ package acme.components;
 import acme.framework.components.Command;
 
 public enum CustomCommand implements Command {
-
+	LIST_PUBLIC_ACTIVE
 }

--- a/src/main/java/acme/features/anonymous/task/AnonymousTaskController.java
+++ b/src/main/java/acme/features/anonymous/task/AnonymousTaskController.java
@@ -6,6 +6,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 
+import acme.components.CustomCommand;
 import acme.framework.components.BasicCommand;
 import acme.framework.controllers.AbstractController;
 import acme.framework.entities.Anonymous;
@@ -18,14 +19,14 @@ public class AnonymousTaskController extends AbstractController<Anonymous, Task>
 	// Internal state ---------------------------------------------------------
 
 	@Autowired
-	private AnonymousTaskListService listService;
+	private AnonymousTaskListPublicActiveService listPublicActiveService;
 	
 	// Constructors -----------------------------------------------------------
 
 	
 	@PostConstruct
 	private void initialise() {
-		super.addBasicCommand(BasicCommand.LIST, this.listService);
+		super.addCustomCommand(CustomCommand.LIST_PUBLIC_ACTIVE, BasicCommand.LIST, this.listPublicActiveService);
 	}
 	
 }

--- a/src/main/java/acme/features/anonymous/task/AnonymousTaskListPublicActiveService.java
+++ b/src/main/java/acme/features/anonymous/task/AnonymousTaskListPublicActiveService.java
@@ -14,7 +14,7 @@ import acme.framework.entities.Task;
 import acme.framework.services.AbstractListService;
 
 @Service
-public class AnonymousTaskListService implements AbstractListService<Anonymous, Task> {
+public class AnonymousTaskListPublicActiveService implements AbstractListService<Anonymous, Task> {
 	
 	// Internal state ---------------------------------------------------------
 

--- a/src/main/webapp/WEB-INF/views/anonymous/task/list.jsp
+++ b/src/main/webapp/WEB-INF/views/anonymous/task/list.jsp
@@ -3,10 +3,10 @@
 <%@taglib prefix="jstl" uri="http://java.sun.com/jsp/jstl/core"%>
 <%@taglib prefix="acme" tagdir="/WEB-INF/tags"%>
 
-<acme:list readonly="true">
-	<acme:list-column code="anonymous.task.list.label.title" path="title" width="15%"/>
-	<acme:list-column code="anonymous.task.list.label.beginning" path="beginning" width="15%"/>
+<acme:list readonly="true" >
+	<acme:list-column code="anonymous.task.list.label.title" path="title" width="15%" sortable="false"/>
+	<acme:list-column code="anonymous.task.list.label.beginning" path="beginning" width="15%" />
 	<acme:list-column code="anonymous.task.list.label.ending" path="ending" width="15%"/>
 	<acme:list-column code="anonymous.task.list.label.workload" path="workload" width="5%"/>
-	<acme:list-column code="anonymous.task.list.label.description" path="description" width="60%"/>	
+	<acme:list-column code="anonymous.task.list.label.description" path="description" width="60%" sortable="false"/>	
 </acme:list>

--- a/src/main/webapp/WEB-INF/views/master/i18n_en.messages
+++ b/src/main/webapp/WEB-INF/views/master/i18n_en.messages
@@ -28,7 +28,7 @@ master.menu.sign-out = Sign out
 # master.menu.anonymous #######################################################
 
 master.menu.anonymous = Anonymous
-master.menu.anonymous.tasks = List tasks
+master.menu.anonymous.public-active-tasks = Public Active Tasks
 master.menu.anonymous.shouts = List shouts
 master.menu.anonymous.create-shout = Shout!
 

--- a/src/main/webapp/WEB-INF/views/master/i18n_es.messages
+++ b/src/main/webapp/WEB-INF/views/master/i18n_es.messages
@@ -28,7 +28,7 @@ master.menu.sign-out = Salir
 # master.menu.anonymous #######################################################
 
 master.menu.anonymous = Anónimo
-master.menu.anonymous.tasks = Lista de tareas
+master.menu.anonymous.public-active-tasks = Tareas públicas activas
 master.menu.anonymous.shouts = Lista de gritos
 master.menu.anonymous.create-shout = Gritar!
 

--- a/src/main/webapp/WEB-INF/views/master/menu.jsp
+++ b/src/main/webapp/WEB-INF/views/master/menu.jsp
@@ -19,7 +19,7 @@
 <acme:menu-bar code="master.menu.home">
 	<acme:menu-left>
 		<acme:menu-option code="master.menu.anonymous" access="isAnonymous()">
-			<acme:menu-suboption code="master.menu.anonymous.tasks" action="/anonymous/task/list"/>
+			<acme:menu-suboption code="master.menu.anonymous.public-active-tasks" action="/anonymous/task/list-public-active"/>
 			<acme:menu-separator/>
 			<acme:menu-suboption code="master.menu.anonymous.shouts" action="/anonymous/shout/list"/>
 			<acme:menu-suboption code="master.menu.anonymous.create-shout" action="/anonymous/shout/create"/>


### PR DESCRIPTION
Se ha personalizado el comando para listar tareas públicas activas y en la vista únicamente se puede ordenar por fechas o workload.