### PR TITLE
Añadidas validaciones y correcciones de entrega anterior.

### DIFF
--- a/src/main/java/acme/features/authenticated/task/AuthenticatedTaskShowService.java
+++ b/src/main/java/acme/features/authenticated/task/AuthenticatedTaskShowService.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Service;
 import acme.framework.components.Model;
 import acme.framework.components.Request;
 import acme.framework.entities.Authenticated;
+import acme.framework.entities.Privacy;
 import acme.framework.entities.Task;
 import acme.framework.services.AbstractShowService;
 
@@ -20,6 +21,9 @@ public class AuthenticatedTaskShowService implements AbstractShowService<Authent
 		@Override
 		public boolean authorise(final Request<Task> request) {
 			assert request != null;
+			
+			assert this.repository.findOneTaskById(request.getModel().getInteger("id"))
+				.getPrivacy().equals(Privacy.PUBLIC);
 			
 			return true;
 		}

--- a/src/main/java/acme/features/manager/task/ManagerTaskShowService.java
+++ b/src/main/java/acme/features/manager/task/ManagerTaskShowService.java
@@ -37,6 +37,7 @@ public class ManagerTaskShowService implements AbstractShowService<Manager, Task
 		assert entity != null;
 		assert model != null;
 		
+		model.setAttribute("workplans", entity.getWorkPlans());
 		request.unbind(entity, model, "title", "beginning", "ending", "workload", "description", "link", "privacy");
 
 	}

--- a/src/main/webapp/WEB-INF/views/manager/task/form.jsp
+++ b/src/main/webapp/WEB-INF/views/manager/task/form.jsp
@@ -14,6 +14,20 @@
 		<acme:form-option code="PUBLIC" value="PUBLIC" selected="${privacy == 'PUBLIC'}"/>
 		<acme:form-option code="PRIVATE" value="PRIVATE" selected="${privacy == 'PRIVATE'}"/>
 	</acme:form-select>
+	<h4>
+		<acme:message code="manager.task.form.label.workplans"/>
+	</h4>
+	
+	<jstl:forEach items="${workplans}" var="workplan">
+		<a href="/Acme-Planner/management/workplan/show?id=${workplan.id}"><acme:print value="${workplan.title} (${workplan.privacy})"></acme:print></a>
+		<br>
+	</jstl:forEach>
+	
+	<jstl:if test="${workplans.size() == 0}">
+		<acme:message code="manager.task.form.label.noWorkplans"/>
+	</jstl:if>
+	
+	<br>
 
 	<acme:form-submit test="${command == 'create'}" code="manager.task.form.button.create" 
 		action="/management/task/create"/>

--- a/src/main/webapp/WEB-INF/views/manager/task/i18n_en.messages
+++ b/src/main/webapp/WEB-INF/views/manager/task/i18n_en.messages
@@ -11,18 +11,24 @@ manager.task.form.label.workload = Workload
 manager.task.form.label.description = Description
 manager.task.form.label.link = Link
 manager.task.form.label.privacy = Privacy
+manager.task.form.label.workplans = Associated Workplans
+manager.task.form.label.noWorkplans = The task is not yet in any Workplan
 
 manager.task.form.beginning.error1 = The beginning must be later than the current one
 manager.task.form.beginning.error2 = The beginning can't be same that the ending
+manager.task.form.beginning.error3 = The begining is before one of the starts of the assigned work plans
 manager.task.form.ending.error1 = The ending must be later than the current one
 manager.task.form.ending.error2 = The ending must be later than the beginning
 manager.task.form.ending.error3 = The ending can't be same that the beginning
+manager.task.form.ending.error4 = The ending exceeds one of the endings of the assigned work plans
+
 manager.task.form.workload.error1 = Workload's decimals must be between 1 and 59
 manager.task.form.workload.error2 = Workload must be a positive greater than 0
 manager.task.form.workload.error3 = Workload must be between beginning and ending
 manager.task.form.workload.error4 = Workload mustn't have more than two decimals
 manager.task.form.title.error = Title contains a lot of spams'words!
 manager.task.form.description.error = Description contains a lot of spams'words!
+manager.task.form.privacy.error = The task is contained in one or more public workplans. Please remove it from them before making it private
 
 PUBLIC = Public
 PRIVATE = Private

--- a/src/main/webapp/WEB-INF/views/manager/task/i18n_es.messages
+++ b/src/main/webapp/WEB-INF/views/manager/task/i18n_es.messages
@@ -11,18 +11,24 @@ manager.task.form.label.workload = Trabajo
 manager.task.form.label.description = Descripción
 manager.task.form.label.link = Enlace
 manager.task.form.label.privacy = Privacidad
+manager.task.form.label.workplans = Planes de trabajo asociados
+manager.task.form.label.noWorkplans = La tarea no se encuentra todavía en ningún plan de trabajo
 
 manager.task.form.beginning.error1 = El comienzo debe ser posterior a la fecha actual
 manager.task.form.beginning.error2 = El comienzo no puede ser igual al final
+manager.task.form.beginning.error3 = El comienzo elegido es anterior a alguno de los inicios de los planes de trabajo asignados
+
 manager.task.form.ending.error1 = El final debe ser posterior a la fecha actual
 manager.task.form.ending.error2 = El final debe ser posterior al comienzo
 manager.task.form.ending.error3 = El final no puede ser igual al comienzo
+manager.task.form.ending.error4 = El final elegido sobrepasa alguno de los finales de los planes de trabajo asignados
 manager.task.form.workload.error1 = Los decimales del trabajo deben estar entre 1 y 59
 manager.task.form.workload.error2 = El trabajo debe ser un positivo mayor que 0
 manager.task.form.workload.error3 = El trabajo debe estar entre en comienzo y el final
 manager.task.form.workload.error4 = El trabajo no debe contener más de dos decimales
 manager.task.form.title.error = ¡El nombre de la tarea contiene demasiadas palabras spam!
 manager.task.form.description.error = ¡La descripción de la tarea contiene demasiadas palabras spam!
+manager.task.form.privacy.error = La tarea está contenida en uno o más planes de trabajo publicos. Por favor, eliminela de ellos antes de cambiarla a privada
 
 PUBLIC = Público
 PRIVATE = Privado


### PR DESCRIPTION
Se ha validado que no se permita actualizar una tarea a privada estando
en un plan de trabajo público, que no se puedan poner fechas no
contenidas en algún plan de trabajo y acceder a tareas privadas como
autenticado.